### PR TITLE
Clarify that easy_install is required and pip won't work

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,12 @@ It's what you'd get if Sinatra and SMTP had a baby.
 Installation
 ------------
 
-*easy_install smtproutes*
+```shell
+$ easy_install smtproutes
+```
+
+**Note:** You must use easy_install here. If you use pip there
+will be conflicting dependencies and things won't work.
 
 Routes
 ------


### PR DESCRIPTION
This commit makes clear that easy_install is _required_ to get a working installation of smtproutes.

A lot of people -- myself included -- are so used to pip and easy_install being interchangeable I thought it would be a good idea to highlight this instance where they aren't.

As best I can tell, it occurs because one dependency requires pydns while another requires dnspython. The end result is an import failure when importing some of the sender_auth stuff.

easy_install avoids the problem by installing the packages as eggs.
