### PR TITLE
Add additional ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ config/environment.json
 *.egg-info
 *.DS_Store
 
+# PyCharm metadata
+.idea/
+
+# Mercurial metadata, for people that use git *only* for pushing to Github
+.hg/
+.hgignore


### PR DESCRIPTION
I propose adding additional ignores in .gitignore.

Firstly to prevent pollution from PyCharm users (it leaves its settings in an '.idea' subdir)

Secondly, to allow people (like me) that uses Git only for pushing to git-only repos (e.g., Github), but use Mercurial day in/day out.

(I know that this is a 'trivial' change... more significant ones a-coming later. I'm doing "logical separation")
