### PR TITLE
Changed pyspf req to >= 1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'secure-smtpd==2.0.0',
         'pydkim==0.3',
         'dnspython',
-        'pyspf==1.4.0',
+        'pyspf>=1.4.0',
         'pydns'
     ],
     tests_require=[


### PR DESCRIPTION
pyspf==1.4.0 no longer available.

Changing to >=1.4.0 passes all tests so we'll try with this one.